### PR TITLE
Adds tab completion to NameLayer commands

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -1,6 +1,6 @@
 name: NameLayer
 main: vg.civcraft.mc.namelayer.NameLayerPlugin
-version: 2.2.2
+version: 2.2.96
 load: startup
 author: Rourke750
 commands:

--- a/plugin.yml
+++ b/plugin.yml
@@ -1,6 +1,6 @@
 name: NameLayer
 main: vg.civcraft.mc.namelayer.NameLayerPlugin
-version: 2.2.95
+version: 2.2.2
 load: startup
 author: Rourke750
 commands:
@@ -25,8 +25,6 @@ commands:
    nlleg:
    nllgt:
    nllpt:
-   nllci:
-   nltaai:
 permissions:
    namelayer.admin:
       default: op

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <groupId>vg.civcraft.mc.namelayer</groupId>
   <artifactId>NameLayer</artifactId>
   <packaging>jar</packaging>
-  <version>2.2.95-${build.number}</version>
+  <version>2.2.2</version>
   <name>NameLayer</name>
   <url>https://github.com/Civcraft/NameLayer/</url>
   

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <groupId>vg.civcraft.mc.namelayer</groupId>
   <artifactId>NameLayer</artifactId>
   <packaging>jar</packaging>
-  <version>2.2.2</version>
+  <version>2.2.96-${build.number}</version>
   <name>NameLayer</name>
   <url>https://github.com/Civcraft/NameLayer/</url>
   

--- a/src/vg/civcraft/mc/namelayer/NameLayerPlugin.java
+++ b/src/vg/civcraft/mc/namelayer/NameLayerPlugin.java
@@ -1,6 +1,7 @@
 package vg.civcraft.mc.namelayer;
 
 import java.io.File;
+import java.util.List;
 import java.util.logging.Level;
 
 import org.bukkit.Bukkit;
@@ -52,7 +53,13 @@ public class NameLayerPlugin extends JavaPlugin{
 			return false;
 		return handle.execute(sender, cmd, args);
 	}
-	
+
+	public List<String> onTabComplete(CommandSender sender, Command cmd, String alias, String[] args){
+		if (!loadGroups)
+			return null;
+		return handle.complete(sender, cmd, args);
+	}
+
 	public void onDisable() {
 		
 	}

--- a/src/vg/civcraft/mc/namelayer/command/Command.java
+++ b/src/vg/civcraft/mc/namelayer/command/Command.java
@@ -2,8 +2,11 @@ package vg.civcraft.mc.namelayer.command;
 
 import org.bukkit.command.CommandSender;
 
+import java.util.List;
+
 public interface Command {
 	public boolean execute(CommandSender sender, String[] args);
+	public List<String> tabComplete	(CommandSender 	sender, String[] args);
 	public String getName();
 	public String getDescription();
 	public String getUsage();

--- a/src/vg/civcraft/mc/namelayer/command/CommandHandler.java
+++ b/src/vg/civcraft/mc/namelayer/command/CommandHandler.java
@@ -1,6 +1,7 @@
 package vg.civcraft.mc.namelayer.command;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.bukkit.ChatColor;
@@ -74,6 +75,15 @@ public class CommandHandler {
 		}
 		return true;
 	}
+
+	public List<String> complete(CommandSender sender, org.bukkit.command.Command cmd, String[] args){
+		if (commands.containsKey(cmd.getName().toLowerCase())){
+			Command command = commands.get(cmd.getName().toLowerCase());
+			return command.tabComplete(sender, args);
+		}
+		return null;
+	}
+
 	
 	public void helpPlayer(Command command, CommandSender sender){
 		sender.sendMessage(new StringBuilder().append(ChatColor.RED + "Command: " ).append(command.getName()).toString());

--- a/src/vg/civcraft/mc/namelayer/command/TabCompleters/GroupTabCompleter.java
+++ b/src/vg/civcraft/mc/namelayer/command/TabCompleters/GroupTabCompleter.java
@@ -1,0 +1,52 @@
+package vg.civcraft.mc.namelayer.command.TabCompleters;
+
+import org.bukkit.entity.Player;
+import vg.civcraft.mc.namelayer.GroupManager;
+import vg.civcraft.mc.namelayer.NameAPI;
+import vg.civcraft.mc.namelayer.NameLayerPlugin;
+import vg.civcraft.mc.namelayer.group.Group;
+import vg.civcraft.mc.namelayer.permission.PermissionType;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.UUID;
+import java.util.logging.Level;
+
+/**
+ * Created by isaac on 2/2/2015.
+ */
+public class GroupTabCompleter {
+    public static List<String> complete(String lastArg, PermissionType accessLevel, Player sender) {
+        UUID uuid = NameAPI.getUUID(sender.getName());
+        GroupManager gm = NameAPI.getGroupManager();
+        List<String> groups = gm.getAllGroupNames(uuid);
+        List<String> fitting_groups = new LinkedList<>();
+        List<String> result = new LinkedList<>();
+
+        if (lastArg != null){
+            for (String group : groups){
+                if (group.startsWith(lastArg)){
+                    fitting_groups.add(group);
+                } else {
+                }
+            }
+        } else {
+            fitting_groups = groups;
+        }
+
+        if (accessLevel == null) {
+            for (String group_name: fitting_groups){
+                Group group  = gm.getGroup(group_name);
+                if (group.isMember(uuid))
+                    result.add(group_name);
+            }
+        } else {
+            for (String group_name : fitting_groups) {
+                Group group = gm.getGroup(group_name);
+                if (gm.getPermissionforGroup(group).isAccessible(group.getPlayerType(uuid), accessLevel))
+                    result.add(group_name);
+            }
+        }
+        return result;
+    }
+}

--- a/src/vg/civcraft/mc/namelayer/command/TabCompleters/InviteTabCompleter.java
+++ b/src/vg/civcraft/mc/namelayer/command/TabCompleters/InviteTabCompleter.java
@@ -1,0 +1,35 @@
+package vg.civcraft.mc.namelayer.command.TabCompleters;
+
+import org.bukkit.entity.Player;
+import vg.civcraft.mc.namelayer.GroupManager;
+import vg.civcraft.mc.namelayer.NameAPI;
+import vg.civcraft.mc.namelayer.group.Group;
+import vg.civcraft.mc.namelayer.listeners.PlayerListener;
+import vg.civcraft.mc.namelayer.permission.PermissionType;
+
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Created by isaac on 2/2/2015.
+ */
+public class InviteTabCompleter {
+    public static List<String> complete(String lastArg, Player sender) {
+        UUID uuid = NameAPI.getUUID(sender.getName());
+        List<Group> groups = PlayerListener.getNotifications(uuid);
+        List<String> result = new LinkedList<>();
+
+        if (groups == null)
+            return new ArrayList<>();
+
+        for (Group group : groups){
+            if (lastArg == null || group.getName().startsWith(lastArg)){
+                result.add(group.getName());
+            }
+        }
+
+        return result;
+    }
+}

--- a/src/vg/civcraft/mc/namelayer/command/TabCompleters/MemberTypeCompleter.java
+++ b/src/vg/civcraft/mc/namelayer/command/TabCompleters/MemberTypeCompleter.java
@@ -1,0 +1,36 @@
+package vg.civcraft.mc.namelayer.command.TabCompleters;
+
+import vg.civcraft.mc.namelayer.GroupManager;
+
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * Created by isaac on 2/2/2015.
+ *
+ * Used by tab completers to get a list of user types
+ */
+public class MemberTypeCompleter {
+
+
+    public static List<String> complete(String lastArg) {
+        GroupManager.PlayerType[] types = GroupManager.PlayerType.values();
+        List<String> type_strings = new LinkedList<>();
+        List<String> result = new LinkedList<>();
+
+        for (GroupManager.PlayerType type: types){
+            type_strings.add(type.toString());
+        }
+
+        if (lastArg != null) {
+            for(String type: type_strings){
+                if (type.startsWith(lastArg))
+                    result.add(type);
+            }
+        } else {
+            result = type_strings;
+        }
+
+        return result;
+    }
+}

--- a/src/vg/civcraft/mc/namelayer/command/TabCompleters/PermissionCompleter.java
+++ b/src/vg/civcraft/mc/namelayer/command/TabCompleters/PermissionCompleter.java
@@ -1,0 +1,37 @@
+package vg.civcraft.mc.namelayer.command.TabCompleters;
+
+import vg.civcraft.mc.namelayer.GroupManager;
+import vg.civcraft.mc.namelayer.permission.PermissionType;
+
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * Created by isaac on 2/2/2015.
+ *
+ * Used by tab completers to get a list of user types
+ */
+public class PermissionCompleter {
+
+
+    public static List<String> complete(String lastArg) {
+        PermissionType[] types = PermissionType.values();
+        List<String> type_strings = new LinkedList<>();
+        List<String> result = new LinkedList<>();
+
+        for (PermissionType type: types){
+            type_strings.add(type.toString());
+        }
+
+        if (lastArg != null) {
+            for(String type: type_strings){
+                if (type.startsWith(lastArg))
+                    result.add(type);
+            }
+        } else {
+            result = type_strings;
+        }
+
+        return result;
+    }
+}

--- a/src/vg/civcraft/mc/namelayer/command/commands/AcceptInvite.java
+++ b/src/vg/civcraft/mc/namelayer/command/commands/AcceptInvite.java
@@ -10,6 +10,7 @@ import org.bukkit.entity.Player;
 import vg.civcraft.mc.namelayer.GroupManager.PlayerType;
 import vg.civcraft.mc.namelayer.NameAPI;
 import vg.civcraft.mc.namelayer.command.PlayerCommand;
+import vg.civcraft.mc.namelayer.command.TabCompleters.InviteTabCompleter;
 import vg.civcraft.mc.namelayer.group.Group;
 import vg.civcraft.mc.namelayer.group.groups.PrivateGroup;
 import vg.civcraft.mc.namelayer.listeners.PlayerListener;
@@ -64,5 +65,16 @@ public class AcceptInvite extends PlayerCommand{
 			}
 		}
 		return true;
+	}
+	@Override
+	public List<String> tabComplete(CommandSender sender, String[] args) {
+		if (!(sender instanceof Player)){
+			return null;
+		}
+
+		if (args.length > 0)
+			return InviteTabCompleter.complete(args[0], (Player) sender);
+		else
+			return InviteTabCompleter.complete(null, (Player)sender);
 	}
 }

--- a/src/vg/civcraft/mc/namelayer/command/commands/AddSuperGroup.java
+++ b/src/vg/civcraft/mc/namelayer/command/commands/AddSuperGroup.java
@@ -1,5 +1,6 @@
 package vg.civcraft.mc.namelayer.command.commands;
 
+import java.util.List;
 import java.util.UUID;
 
 import org.bukkit.ChatColor;
@@ -9,6 +10,7 @@ import org.bukkit.entity.Player;
 import vg.civcraft.mc.namelayer.GroupManager.PlayerType;
 import vg.civcraft.mc.namelayer.NameAPI;
 import vg.civcraft.mc.namelayer.command.PlayerCommand;
+import vg.civcraft.mc.namelayer.command.TabCompleters.GroupTabCompleter;
 import vg.civcraft.mc.namelayer.group.Group;
 import vg.civcraft.mc.namelayer.group.GroupType;
 import vg.civcraft.mc.namelayer.group.groups.PrivateGroup;
@@ -78,4 +80,17 @@ public class AddSuperGroup extends PlayerCommand{
 		return true;
 	}
 
+	@Override
+	public List<String> tabComplete(CommandSender sender, String[] args) {
+		if (!(sender instanceof Player)){
+			sender.sendMessage(ChatColor.BLUE + "Fight me, bet you wont.\n Just back off you don't belong here.");
+			return null;
+		}
+
+		if (args.length > 0)
+			return GroupTabCompleter.complete(args[args.length - 1], PermissionType.SUBGROUP, (Player) sender);
+		else{
+			return  GroupTabCompleter.complete(null, PermissionType.SUBGROUP,(Player)sender);
+		}
+	}
 }

--- a/src/vg/civcraft/mc/namelayer/command/commands/CreateGroup.java
+++ b/src/vg/civcraft/mc/namelayer/command/commands/CreateGroup.java
@@ -1,5 +1,6 @@
 package vg.civcraft.mc.namelayer.command.commands;
 
+import java.util.List;
 import java.util.UUID;
 
 import org.bukkit.ChatColor;
@@ -58,4 +59,7 @@ public class CreateGroup extends PlayerCommand{
 		return true;
 	}
 
+	public List<String> tabComplete(CommandSender sender, String[] args) {
+		return null;
+	}
 }

--- a/src/vg/civcraft/mc/namelayer/command/commands/DeleteGroup.java
+++ b/src/vg/civcraft/mc/namelayer/command/commands/DeleteGroup.java
@@ -1,5 +1,6 @@
 package vg.civcraft.mc.namelayer.command.commands;
 
+import java.util.List;
 import java.util.UUID;
 
 import org.bukkit.ChatColor;
@@ -9,6 +10,7 @@ import org.bukkit.entity.Player;
 import vg.civcraft.mc.namelayer.GroupManager.PlayerType;
 import vg.civcraft.mc.namelayer.NameAPI;
 import vg.civcraft.mc.namelayer.command.PlayerCommand;
+import vg.civcraft.mc.namelayer.command.TabCompleters.GroupTabCompleter;
 import vg.civcraft.mc.namelayer.group.Group;
 import vg.civcraft.mc.namelayer.permission.GroupPermission;
 import vg.civcraft.mc.namelayer.permission.PermissionType;
@@ -59,4 +61,16 @@ public class DeleteGroup extends PlayerCommand{
 		return true;
 	}
 
+	@Override
+	public List<String> tabComplete(CommandSender sender, String[] args) {
+		if (!(sender instanceof Player)){
+			return null;
+		}
+
+		if (args.length > 0)
+			return GroupTabCompleter.complete(args[args.length - 1], PermissionType.DELETE, (Player) sender);
+		else {
+			return GroupTabCompleter.complete(null, PermissionType.DELETE, (Player) sender);
+		}
+	}
 }

--- a/src/vg/civcraft/mc/namelayer/command/commands/DisciplineGroup.java
+++ b/src/vg/civcraft/mc/namelayer/command/commands/DisciplineGroup.java
@@ -7,6 +7,8 @@ import org.bukkit.entity.Player;
 import vg.civcraft.mc.namelayer.command.PlayerCommand;
 import vg.civcraft.mc.namelayer.group.Group;
 
+import java.util.List;
+
 public class DisciplineGroup extends PlayerCommand{
 
 	public DisciplineGroup(String name) {
@@ -42,5 +44,10 @@ public class DisciplineGroup extends PlayerCommand{
 		sender.sendMessage(ChatColor.GREEN + "Group has been disabled.");
 		}
 		return true;
+	}
+
+	@Override
+	public List<String> tabComplete(CommandSender sender, String[] args) {
+		return null;
 	}
 }

--- a/src/vg/civcraft/mc/namelayer/command/commands/GlobalStats.java
+++ b/src/vg/civcraft/mc/namelayer/command/commands/GlobalStats.java
@@ -7,6 +7,8 @@ import org.bukkit.command.CommandSender;
 import vg.civcraft.mc.namelayer.NameLayerPlugin;
 import vg.civcraft.mc.namelayer.command.PlayerCommand;
 
+import java.util.List;
+
 public class GlobalStats extends PlayerCommand{
 
 	public GlobalStats(String name) {
@@ -32,4 +34,8 @@ public class GlobalStats extends PlayerCommand{
 		return true;
 	}
 
+	@Override
+	public List<String> tabComplete(CommandSender sender, String[] args) {
+		return null;
+	}
 }

--- a/src/vg/civcraft/mc/namelayer/command/commands/GroupStats.java
+++ b/src/vg/civcraft/mc/namelayer/command/commands/GroupStats.java
@@ -1,5 +1,6 @@
 package vg.civcraft.mc.namelayer.command.commands;
 
+import java.util.List;
 import java.util.UUID;
 
 import org.bukkit.Bukkit;
@@ -11,7 +12,9 @@ import vg.civcraft.mc.namelayer.GroupManager.PlayerType;
 import vg.civcraft.mc.namelayer.NameAPI;
 import vg.civcraft.mc.namelayer.NameLayerPlugin;
 import vg.civcraft.mc.namelayer.command.PlayerCommand;
+import vg.civcraft.mc.namelayer.command.TabCompleters.GroupTabCompleter;
 import vg.civcraft.mc.namelayer.group.Group;
+import vg.civcraft.mc.namelayer.permission.PermissionType;
 
 public class GroupStats extends PlayerCommand {
 
@@ -45,6 +48,19 @@ public class GroupStats extends PlayerCommand {
 		Bukkit.getScheduler().runTaskAsynchronously(NameLayerPlugin.getInstance(), new StatsMessage(p, g));
 		
 		return true;
+	}
+
+
+	@Override
+	public List<String> tabComplete(CommandSender sender, String[] args) {
+		if (!(sender instanceof Player))
+			return null;
+
+		if (args.length > 0)
+			return GroupTabCompleter.complete(args[args.length - 1], null, (Player) sender);
+		else {
+			return GroupTabCompleter.complete(null, null, (Player) sender);
+		}
 	}
 
 	public class StatsMessage implements Runnable{

--- a/src/vg/civcraft/mc/namelayer/command/commands/InvitePlayer.java
+++ b/src/vg/civcraft/mc/namelayer/command/commands/InvitePlayer.java
@@ -13,6 +13,8 @@ import vg.civcraft.mc.namelayer.GroupManager.PlayerType;
 import vg.civcraft.mc.namelayer.NameAPI;
 import vg.civcraft.mc.namelayer.NameLayerPlugin;
 import vg.civcraft.mc.namelayer.command.PlayerCommand;
+import vg.civcraft.mc.namelayer.command.TabCompleters.GroupTabCompleter;
+import vg.civcraft.mc.namelayer.command.TabCompleters.MemberTypeCompleter;
 import vg.civcraft.mc.namelayer.database.GroupManagerDao;
 import vg.civcraft.mc.namelayer.group.Group;
 import vg.civcraft.mc.namelayer.group.groups.PrivateGroup;
@@ -128,4 +130,24 @@ public class InvitePlayer extends PlayerCommand{
 		return true;
 	}
 
+	@Override
+	public List<String> tabComplete(CommandSender sender, String[] args) {
+		if (!(sender instanceof Player)){
+			sender.sendMessage(ChatColor.RED + "I'm sorry baby, please run this as a player :)");
+			return null;
+		}
+		if (args.length < 2) {
+			if (args.length == 0)
+				return GroupTabCompleter.complete(null, null, (Player) sender);
+			else
+				return GroupTabCompleter.complete(args[0], null, (Player)sender);
+
+		} else if (args.length == 2)
+			return null;
+
+		else if (args.length == 3)
+			return MemberTypeCompleter.complete(args[2]);
+
+		else return null;
+	}
 }

--- a/src/vg/civcraft/mc/namelayer/command/commands/JoinGroup.java
+++ b/src/vg/civcraft/mc/namelayer/command/commands/JoinGroup.java
@@ -1,5 +1,6 @@
 package vg.civcraft.mc.namelayer.command.commands;
 
+import java.util.List;
 import java.util.UUID;
 
 import org.bukkit.ChatColor;
@@ -67,5 +68,10 @@ public class JoinGroup extends PlayerCommand{
 		p.sendMessage(ChatColor.GREEN + "You have successfully been added to this group.");
 		return true;
 	}
+
+	public List<String> tabComplete(CommandSender sender, String[] args) {
+		return null;
+	}
+
 
 }

--- a/src/vg/civcraft/mc/namelayer/command/commands/LeaveGroup.java
+++ b/src/vg/civcraft/mc/namelayer/command/commands/LeaveGroup.java
@@ -1,5 +1,6 @@
 package vg.civcraft.mc.namelayer.command.commands;
 
+import java.util.List;
 import java.util.UUID;
 
 import org.bukkit.ChatColor;
@@ -8,6 +9,7 @@ import org.bukkit.entity.Player;
 
 import vg.civcraft.mc.namelayer.NameAPI;
 import vg.civcraft.mc.namelayer.command.PlayerCommand;
+import vg.civcraft.mc.namelayer.command.TabCompleters.GroupTabCompleter;
 import vg.civcraft.mc.namelayer.group.Group;
 
 public class LeaveGroup extends PlayerCommand{
@@ -46,4 +48,15 @@ public class LeaveGroup extends PlayerCommand{
 		return true;
 	}
 
+	@Override
+	public List<String> tabComplete(CommandSender sender, String[] args) {
+		if (!(sender instanceof Player))
+			return null;
+
+		if (args.length > 0)
+			return GroupTabCompleter.complete(args[0], null, (Player) sender);
+		else{
+			return GroupTabCompleter.complete(null, null, (Player)sender);
+		}
+	}
 }

--- a/src/vg/civcraft/mc/namelayer/command/commands/ListCurrentInvites.java
+++ b/src/vg/civcraft/mc/namelayer/command/commands/ListCurrentInvites.java
@@ -7,6 +7,8 @@ import vg.civcraft.mc.namelayer.NameAPI;
 import vg.civcraft.mc.namelayer.command.PlayerCommand;
 import vg.civcraft.mc.namelayer.listeners.PlayerListener;
 
+import java.util.List;
+
 public class ListCurrentInvites extends PlayerCommand{
 
 	public ListCurrentInvites(String name) {
@@ -26,6 +28,9 @@ public class ListCurrentInvites extends PlayerCommand{
 		Player p = (Player) sender;
 		p.sendMessage(PlayerListener.getNotificationsInStringForm(NameAPI.getUUID(p.getName())));
 		return true;
+	}
+	public List<String> tabComplete(CommandSender sender, String[] args) {
+		return null;
 	}
 
 }

--- a/src/vg/civcraft/mc/namelayer/command/commands/ListGroupTypes.java
+++ b/src/vg/civcraft/mc/namelayer/command/commands/ListGroupTypes.java
@@ -6,6 +6,8 @@ import org.bukkit.entity.Player;
 import vg.civcraft.mc.namelayer.command.PlayerCommand;
 import vg.civcraft.mc.namelayer.group.GroupType;
 
+import java.util.List;
+
 public class ListGroupTypes extends PlayerCommand{
 
 	public ListGroupTypes(String name) {
@@ -25,6 +27,10 @@ public class ListGroupTypes extends PlayerCommand{
 		Player p = (Player) sender;
 		GroupType.displayGroupTypes(p);
 		return true;
+	}
+
+	public List<String> tabComplete(CommandSender sender, String[] args) {
+		return null;
 	}
 
 }

--- a/src/vg/civcraft/mc/namelayer/command/commands/ListGroups.java
+++ b/src/vg/civcraft/mc/namelayer/command/commands/ListGroups.java
@@ -52,5 +52,8 @@ public class ListGroups extends PlayerCommand {
 		p.sendMessage(names);
 		return true;
 	}
+	public List<String> tabComplete(CommandSender sender, String[] args) {
+		return null;
+	}
 
 }

--- a/src/vg/civcraft/mc/namelayer/command/commands/ListMembers.java
+++ b/src/vg/civcraft/mc/namelayer/command/commands/ListMembers.java
@@ -10,6 +10,8 @@ import org.bukkit.entity.Player;
 import vg.civcraft.mc.namelayer.GroupManager.PlayerType;
 import vg.civcraft.mc.namelayer.NameAPI;
 import vg.civcraft.mc.namelayer.command.PlayerCommand;
+import vg.civcraft.mc.namelayer.command.TabCompleters.GroupTabCompleter;
+import vg.civcraft.mc.namelayer.command.TabCompleters.MemberTypeCompleter;
 import vg.civcraft.mc.namelayer.group.Group;
 
 public class ListMembers extends PlayerCommand{
@@ -58,4 +60,18 @@ public class ListMembers extends PlayerCommand{
 		return true;
 	}
 
+	@Override
+	public List<String> tabComplete(CommandSender sender, String[] args) {
+		if (!(sender instanceof Player))
+			return null;
+
+		if (args.length == 0)
+			return GroupTabCompleter.complete(null, null, (Player) sender);
+		else if (args.length == 1)
+			return GroupTabCompleter.complete(args[0], null, (Player)sender);
+		else if (args.length == 2)
+			return MemberTypeCompleter.complete(args[1]);
+
+		return null;
+	}
 }

--- a/src/vg/civcraft/mc/namelayer/command/commands/ListPermissions.java
+++ b/src/vg/civcraft/mc/namelayer/command/commands/ListPermissions.java
@@ -1,5 +1,6 @@
 package vg.civcraft.mc.namelayer.command.commands;
 
+import java.util.List;
 import java.util.UUID;
 
 import org.bukkit.ChatColor;
@@ -9,6 +10,8 @@ import org.bukkit.entity.Player;
 import vg.civcraft.mc.namelayer.GroupManager.PlayerType;
 import vg.civcraft.mc.namelayer.NameAPI;
 import vg.civcraft.mc.namelayer.command.PlayerCommand;
+import vg.civcraft.mc.namelayer.command.TabCompleters.GroupTabCompleter;
+import vg.civcraft.mc.namelayer.command.TabCompleters.MemberTypeCompleter;
 import vg.civcraft.mc.namelayer.group.Group;
 import vg.civcraft.mc.namelayer.permission.GroupPermission;
 import vg.civcraft.mc.namelayer.permission.PermissionType;
@@ -56,6 +59,21 @@ public class ListPermissions extends PlayerCommand{
 		String types = gPerm.listPermsforPlayerType(check);
 		p.sendMessage(ChatColor.GREEN + types);
 		return true;
+	}
+
+	@Override
+	public List<String> tabComplete(CommandSender sender, String[] args) {
+		if (!(sender instanceof Player))
+			return null;
+
+		if (args.length == 0)
+			return GroupTabCompleter.complete(null, null, (Player) sender);
+		else if (args.length == 1)
+			return GroupTabCompleter.complete(args[0], null, (Player)sender);
+		else if (args.length == 2)
+			return MemberTypeCompleter.complete(args[1]);
+
+		return  null;
 	}
 
 }

--- a/src/vg/civcraft/mc/namelayer/command/commands/ListPlayerTypes.java
+++ b/src/vg/civcraft/mc/namelayer/command/commands/ListPlayerTypes.java
@@ -6,6 +6,8 @@ import org.bukkit.entity.Player;
 import vg.civcraft.mc.namelayer.GroupManager.PlayerType;
 import vg.civcraft.mc.namelayer.command.PlayerCommand;
 
+import java.util.List;
+
 public class ListPlayerTypes extends PlayerCommand{
 
 	public ListPlayerTypes(String name) {
@@ -27,4 +29,7 @@ public class ListPlayerTypes extends PlayerCommand{
 		return true;
 	}
 
+	public List<String> tabComplete(CommandSender sender, String[] args) {
+		return null;
+	}
 }

--- a/src/vg/civcraft/mc/namelayer/command/commands/MergeGroups.java
+++ b/src/vg/civcraft/mc/namelayer/command/commands/MergeGroups.java
@@ -1,5 +1,6 @@
 package vg.civcraft.mc.namelayer.command.commands;
 
+import java.util.List;
 import java.util.UUID;
 
 import org.bukkit.Bukkit;
@@ -11,6 +12,7 @@ import vg.civcraft.mc.namelayer.GroupManager.PlayerType;
 import vg.civcraft.mc.namelayer.NameAPI;
 import vg.civcraft.mc.namelayer.NameLayerPlugin;
 import vg.civcraft.mc.namelayer.command.PlayerCommand;
+import vg.civcraft.mc.namelayer.command.TabCompleters.GroupTabCompleter;
 import vg.civcraft.mc.namelayer.group.Group;
 import vg.civcraft.mc.namelayer.permission.GroupPermission;
 import vg.civcraft.mc.namelayer.permission.PermissionType;
@@ -91,4 +93,15 @@ public class MergeGroups extends PlayerCommand{
 		return true;
 	}
 
+	@Override
+	public List<String> tabComplete(CommandSender sender, String[] args) {
+		if (!(sender instanceof Player))
+			return null;
+
+		if (args.length > 0)
+			return GroupTabCompleter.complete(args[args.length - 1], PermissionType.MERGE, (Player) sender);
+		else{
+			return  GroupTabCompleter.complete(null, PermissionType.MERGE,(Player)sender);
+		}
+	}
 }

--- a/src/vg/civcraft/mc/namelayer/command/commands/ModifyPermissions.java
+++ b/src/vg/civcraft/mc/namelayer/command/commands/ModifyPermissions.java
@@ -1,5 +1,6 @@
 package vg.civcraft.mc.namelayer.command.commands;
 
+import java.util.List;
 import java.util.UUID;
 
 import org.bukkit.ChatColor;
@@ -9,6 +10,9 @@ import org.bukkit.entity.Player;
 import vg.civcraft.mc.namelayer.GroupManager.PlayerType;
 import vg.civcraft.mc.namelayer.NameAPI;
 import vg.civcraft.mc.namelayer.command.PlayerCommand;
+import vg.civcraft.mc.namelayer.command.TabCompleters.GroupTabCompleter;
+import vg.civcraft.mc.namelayer.command.TabCompleters.MemberTypeCompleter;
+import vg.civcraft.mc.namelayer.command.TabCompleters.PermissionCompleter;
 import vg.civcraft.mc.namelayer.group.Group;
 import vg.civcraft.mc.namelayer.permission.GroupPermission;
 import vg.civcraft.mc.namelayer.permission.PermissionType;
@@ -84,5 +88,32 @@ public class ModifyPermissions extends PlayerCommand{
 			p.sendMessage(ChatColor.RED + "Specify if you want to add or remove.");
 		}
 		return true;
+	}
+
+	@Override
+	public List<String> tabComplete(CommandSender sender, String[] args) {
+		if (!(sender instanceof Player))
+			return null;
+
+		if (args.length == 0)
+			return GroupTabCompleter.complete(null, PermissionType.PERMS, (Player) sender);
+		else if (args.length == 1)
+			return GroupTabCompleter.complete(args[0], PermissionType.PERMS, (Player)sender);
+		else if (args.length == 2) {
+
+			if (args[1].length() > 0) {
+				if (args[1].charAt(0) == 'a') return java.util.Arrays.asList(new String[]{"add"});
+				else if (args[1].charAt(0) == 'r') return java.util.Arrays.asList(new String[]{"remove"});
+			} else {
+				return java.util.Arrays.asList(new String[]{"add", "remove"});
+			}
+
+		} else if (args.length == 3) {
+			return MemberTypeCompleter.complete(args[2]);
+		} else if (args.length == 4) {
+			return PermissionCompleter.complete(args[3]);
+		}
+
+		return  null;
 	}
 }

--- a/src/vg/civcraft/mc/namelayer/command/commands/RemoveMember.java
+++ b/src/vg/civcraft/mc/namelayer/command/commands/RemoveMember.java
@@ -1,5 +1,6 @@
 package vg.civcraft.mc.namelayer.command.commands;
 
+import java.util.List;
 import java.util.UUID;
 
 import org.bukkit.ChatColor;
@@ -9,6 +10,7 @@ import org.bukkit.entity.Player;
 import vg.civcraft.mc.namelayer.GroupManager.PlayerType;
 import vg.civcraft.mc.namelayer.NameAPI;
 import vg.civcraft.mc.namelayer.command.PlayerCommand;
+import vg.civcraft.mc.namelayer.command.TabCompleters.GroupTabCompleter;
 import vg.civcraft.mc.namelayer.group.Group;
 import vg.civcraft.mc.namelayer.permission.GroupPermission;
 import vg.civcraft.mc.namelayer.permission.PermissionType;
@@ -93,6 +95,23 @@ public class RemoveMember extends PlayerCommand {
 		p.sendMessage(ChatColor.GREEN + "Player has been removed from the group.");
 		group.removeMember(uuid);
 		return true;
+	}
+
+
+	@Override
+	public List<String> tabComplete(CommandSender sender, String[] args) {
+		if (!(sender instanceof Player))
+			return null;
+
+		if (args.length < 2) {
+			if (args.length == 1)
+				return GroupTabCompleter.complete(args[0], null, (Player) sender);
+			else {
+				return GroupTabCompleter.complete(null, null, (Player)sender);
+			}
+		}
+
+		return null;
 	}
 
 }

--- a/src/vg/civcraft/mc/namelayer/command/commands/RemoveSuperGroup.java
+++ b/src/vg/civcraft/mc/namelayer/command/commands/RemoveSuperGroup.java
@@ -1,5 +1,6 @@
 package vg.civcraft.mc.namelayer.command.commands;
 
+import java.util.List;
 import java.util.UUID;
 
 import org.bukkit.ChatColor;
@@ -9,6 +10,7 @@ import org.bukkit.entity.Player;
 import vg.civcraft.mc.namelayer.GroupManager.PlayerType;
 import vg.civcraft.mc.namelayer.NameAPI;
 import vg.civcraft.mc.namelayer.command.PlayerCommand;
+import vg.civcraft.mc.namelayer.command.TabCompleters.GroupTabCompleter;
 import vg.civcraft.mc.namelayer.group.Group;
 import vg.civcraft.mc.namelayer.group.groups.PrivateGroup;
 import vg.civcraft.mc.namelayer.permission.GroupPermission;
@@ -69,4 +71,15 @@ public class RemoveSuperGroup extends PlayerCommand{
 		return true;
 	}
 
+	@Override
+	public List<String> tabComplete(CommandSender sender, String[] args) {
+		if (!(sender instanceof Player))
+			return null;
+
+		if (args.length > 0)
+			return GroupTabCompleter.complete(args[0], PermissionType.SUBGROUP, (Player) sender);
+		else{
+			return GroupTabCompleter.complete(null, PermissionType.SUBGROUP, (Player)sender);
+		}
+	}
 }

--- a/src/vg/civcraft/mc/namelayer/command/commands/SetPassword.java
+++ b/src/vg/civcraft/mc/namelayer/command/commands/SetPassword.java
@@ -1,5 +1,6 @@
 package vg.civcraft.mc.namelayer.command.commands;
 
+import java.util.List;
 import java.util.UUID;
 
 import org.bukkit.ChatColor;
@@ -9,6 +10,7 @@ import org.bukkit.entity.Player;
 import vg.civcraft.mc.namelayer.GroupManager.PlayerType;
 import vg.civcraft.mc.namelayer.NameAPI;
 import vg.civcraft.mc.namelayer.command.PlayerCommand;
+import vg.civcraft.mc.namelayer.command.TabCompleters.GroupTabCompleter;
 import vg.civcraft.mc.namelayer.group.Group;
 import vg.civcraft.mc.namelayer.permission.GroupPermission;
 import vg.civcraft.mc.namelayer.permission.PermissionType;
@@ -56,4 +58,15 @@ public class SetPassword extends PlayerCommand{
 		return true;
 	}
 
+	@Override
+	public List<String> tabComplete(CommandSender sender, String[] args) {
+		if (!(sender instanceof Player))
+			return null;
+
+		if (args.length == 1)
+			return GroupTabCompleter.complete(args[0], PermissionType.PASSWORD, (Player) sender);
+		else{
+			return GroupTabCompleter.complete(null, PermissionType.PASSWORD, (Player)sender);
+		}
+	}
 }

--- a/src/vg/civcraft/mc/namelayer/command/commands/ToggleAutoAcceptInvites.java
+++ b/src/vg/civcraft/mc/namelayer/command/commands/ToggleAutoAcceptInvites.java
@@ -1,5 +1,6 @@
 package vg.civcraft.mc.namelayer.command.commands;
 
+import java.util.List;
 import java.util.UUID;
 
 import org.bukkit.ChatColor;
@@ -39,6 +40,10 @@ public class ToggleAutoAcceptInvites extends PlayerCommand{
 			p.sendMessage(ChatColor.GREEN + "You will automatically accept group requests.");
 		}
 		return true;
+	}
+
+	public List<String> tabComplete(CommandSender sender, String[] args) {
+		return null;
 	}
 
 }

--- a/src/vg/civcraft/mc/namelayer/command/commands/TransferGroup.java
+++ b/src/vg/civcraft/mc/namelayer/command/commands/TransferGroup.java
@@ -1,5 +1,6 @@
 package vg.civcraft.mc.namelayer.command.commands;
 
+import java.util.List;
 import java.util.UUID;
 
 import org.bukkit.ChatColor;
@@ -9,6 +10,7 @@ import org.bukkit.entity.Player;
 import vg.civcraft.mc.namelayer.GroupManager.PlayerType;
 import vg.civcraft.mc.namelayer.NameAPI;
 import vg.civcraft.mc.namelayer.command.PlayerCommand;
+import vg.civcraft.mc.namelayer.command.TabCompleters.GroupTabCompleter;
 import vg.civcraft.mc.namelayer.group.Group;
 import vg.civcraft.mc.namelayer.permission.GroupPermission;
 import vg.civcraft.mc.namelayer.permission.PermissionType;
@@ -65,6 +67,19 @@ public class TransferGroup extends PlayerCommand{
 		g.setOwner(oPlayer);
 		p.sendMessage(ChatColor.GREEN + NameAPI.getCurrentName(oPlayer) + " has been given ownership of the group.");
 		return true;
+	}
+
+	@Override
+	public List<String> tabComplete(CommandSender sender, String[] args) {
+		if (!(sender instanceof Player))
+			return null;
+
+		if (args.length == 1)
+			return GroupTabCompleter.complete(args[0], PermissionType.TRANSFER, (Player) sender);
+		else if (args.length == 0) {
+			return GroupTabCompleter.complete(null, PermissionType.TRANSFER, (Player)sender);
+		}
+		return null;
 	}
 
 }

--- a/src/vg/civcraft/mc/namelayer/listeners/PlayerListener.java
+++ b/src/vg/civcraft/mc/namelayer/listeners/PlayerListener.java
@@ -29,7 +29,7 @@ public class PlayerListener implements Listener{
 			return;
 		String x = "You have been invited to the following groups while you were away: ";
 		
-		for (Group g: notifications.get(uuid)){
+		for (Group g:notifications .get(uuid)){
 			x += g.getName() + ", ";
 		}
 		x = x.substring(0, x.length()- 2);
@@ -41,6 +41,10 @@ public class PlayerListener implements Listener{
 		if (!notifications.containsKey(u))
 			notifications.put(u, new ArrayList<Group>());
 		notifications.get(u).add(g);
+	}
+
+	public static List<Group> getNotifications(UUID player) {
+		return notifications.get(player);
 	}
 	
 	public static void removeNotification(UUID u, Group g){


### PR DESCRIPTION
This should add tab completion where it makes sense to NameLayer command. It should, however, not give users any more info than they would have gotten by using other commands. It should also be simi-smart about it's suggestions not suggesting groups that the user doesn't have the right permission to use the command with. There's a lot of changes but to summarize I've added tab completion to every argument in every command in NameLayer except those dealing with admin stuff. Tab completion for admins also won't list the full set of options they have.

If this gets accepted it should also be easy to add the this functionality to Citadel.