### PR TITLE
Adds a command to change a players name

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -1,6 +1,6 @@
 name: NameLayer
 main: vg.civcraft.mc.namelayer.NameLayerPlugin
-version: 2.3.0
+version: 2.3.1
 load: startup
 author: Rourke750
 commands:

--- a/plugin.yml
+++ b/plugin.yml
@@ -29,6 +29,8 @@ commands:
    nllpt:
    nllci:
    nltaai:
+   nlcpn:
+      permission: namelayer.admin
 permissions:
    namelayer.admin:
       default: op

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <groupId>vg.civcraft.mc.namelayer</groupId>
   <artifactId>NameLayer</artifactId>
   <packaging>jar</packaging>
-  <version>2.3.0-${build.number}</version>
+  <version>2.3.1-${build.number}</version>
   <name>NameLayer</name>
   <url>https://github.com/Civcraft/NameLayer/</url>
   

--- a/src/vg/civcraft/mc/namelayer/command/CommandHandler.java
+++ b/src/vg/civcraft/mc/namelayer/command/CommandHandler.java
@@ -7,30 +7,7 @@ import java.util.Map;
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
 
-import vg.civcraft.mc.namelayer.command.commands.AcceptInvite;
-import vg.civcraft.mc.namelayer.command.commands.CreateGroup;
-import vg.civcraft.mc.namelayer.command.commands.DeleteGroup;
-import vg.civcraft.mc.namelayer.command.commands.DisciplineGroup;
-import vg.civcraft.mc.namelayer.command.commands.GlobalStats;
-import vg.civcraft.mc.namelayer.command.commands.GroupStats;
-import vg.civcraft.mc.namelayer.command.commands.InvitePlayer;
-import vg.civcraft.mc.namelayer.command.commands.JoinGroup;
-import vg.civcraft.mc.namelayer.command.commands.LeaveGroup;
-import vg.civcraft.mc.namelayer.command.commands.ListCurrentInvites;
-import vg.civcraft.mc.namelayer.command.commands.ListGroupTypes;
-import vg.civcraft.mc.namelayer.command.commands.ListGroups;
-import vg.civcraft.mc.namelayer.command.commands.ListMembers;
-import vg.civcraft.mc.namelayer.command.commands.ListPermissions;
-import vg.civcraft.mc.namelayer.command.commands.ListPlayerTypes;
-import vg.civcraft.mc.namelayer.command.commands.MergeGroups;
-import vg.civcraft.mc.namelayer.command.commands.ModifyPermissions;
-import vg.civcraft.mc.namelayer.command.commands.RemoveMember;
-import vg.civcraft.mc.namelayer.command.commands.RemoveSuperGroup;
-import vg.civcraft.mc.namelayer.command.commands.SetPassword;
-import vg.civcraft.mc.namelayer.command.commands.ToggleAutoAcceptInvites;
-import vg.civcraft.mc.namelayer.command.commands.TransferGroup;
-import vg.civcraft.mc.namelayer.command.commands.PromotePlayer;
-import vg.civcraft.mc.namelayer.command.commands.RevokeInvite;
+import vg.civcraft.mc.namelayer.command.commands.*;
 
 public class CommandHandler {
 	public Map<String, Command> commands = new HashMap<String, Command>();
@@ -62,6 +39,7 @@ public class CommandHandler {
 		addCommands(new ToggleAutoAcceptInvites("AutoAcceptInvites"));
 		addCommands(new PromotePlayer("PromotePlayer"));
 		addCommands(new RevokeInvite("RevokeInvite"));
+		addCommands(new ChangePlayerName("ChangePlayerName"));
 	}
 	
 	public void addCommands(Command command){

--- a/src/vg/civcraft/mc/namelayer/command/commands/ChangePlayerName.java
+++ b/src/vg/civcraft/mc/namelayer/command/commands/ChangePlayerName.java
@@ -1,5 +1,6 @@
 package vg.civcraft.mc.namelayer.command.commands;
 
+import org.bukkit.Bukkit;
 import org.bukkit.command.CommandSender;
 import vg.civcraft.mc.namelayer.NameAPI;
 import vg.civcraft.mc.namelayer.command.PlayerCommand;
@@ -32,9 +33,10 @@ public class ChangePlayerName  extends PlayerCommand {
             return false;
         }
 
-        String newName = args[1].substring(0,16);
+        String newName = args[1].length() >= 16 ? args[1].substring(0, 16) : args[1];
         NameAPI.getAssociationList().changePlayer(newName, player);
 
+        sender.sendMessage("player name changed have them relog for it to take affect");
         return true;
     }
 

--- a/src/vg/civcraft/mc/namelayer/command/commands/ChangePlayerName.java
+++ b/src/vg/civcraft/mc/namelayer/command/commands/ChangePlayerName.java
@@ -1,0 +1,45 @@
+package vg.civcraft.mc.namelayer.command.commands;
+
+import org.bukkit.command.CommandSender;
+import vg.civcraft.mc.namelayer.NameAPI;
+import vg.civcraft.mc.namelayer.command.PlayerCommand;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Created by isaac on 2/6/15.
+ */
+public class ChangePlayerName  extends PlayerCommand {
+    public ChangePlayerName(String name) {
+        super(name);
+        setIdentifier("nlcpn");
+        setDescription("This command is used by ops to change a players name");
+        setUsage("/nlcpn <old name> <new name>");
+        setArguments(2,2);
+    }
+
+    @Override
+    public boolean execute(CommandSender sender, String[] args) {
+        if (!sender.isOp() && !sender.hasPermission("namelayer.admin")) {
+            sender.sendMessage("You're not an op. ");
+            return false;
+        }
+
+        UUID player = NameAPI.getUUID(args[0]);
+        if (player == null){
+            sender.sendMessage(args[0] + " has never logged in");
+            return false;
+        }
+
+        String newName = args[1].substring(0,16);
+        NameAPI.getAssociationList().changePlayer(newName, player);
+
+        return true;
+    }
+
+    @Override
+    public List<String> tabComplete(CommandSender sender, String[] args) {
+        return null;
+    }
+}

--- a/src/vg/civcraft/mc/namelayer/database/AssociationList.java
+++ b/src/vg/civcraft/mc/namelayer/database/AssociationList.java
@@ -38,12 +38,16 @@ public class AssociationList {
 	private PreparedStatement addPlayer;
     private PreparedStatement getUUIDfromPlayer;
     private PreparedStatement getPlayerfromUUID;
+	private PreparedStatement changePlayerName;
 	
 	public void initializeStatements(){
 		addPlayer = db.prepareStatement("call addplayertotable(?, ?)"); // order player name, uuid 
 		getUUIDfromPlayer = db.prepareStatement("select uuid from Name_player " +
 				"where player=?");
 		getPlayerfromUUID = db.prepareStatement("select player from Name_player " +
+				"where uuid=?");
+
+		changePlayerName = db.prepareStatement("delete from Name_player " +
 				"where uuid=?");
 	}
 	
@@ -129,6 +133,17 @@ public class AssociationList {
 			addPlayer.setString(1, playername);
 			addPlayer.setString(2, uuid.toString());
 			addPlayer.execute();
+		} catch (SQLException e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		}
+	}
+	public void changePlayer(String newName, UUID uuid) {
+		NameLayerPlugin.reconnectAndReintializeStatements();
+		try {
+			changePlayerName.setString(1, uuid.toString());
+			changePlayerName.execute();
+			addPlayer(newName, uuid);
 		} catch (SQLException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();

--- a/src/vg/civcraft/mc/namelayer/listeners/AssociationListener.java
+++ b/src/vg/civcraft/mc/namelayer/listeners/AssociationListener.java
@@ -2,6 +2,7 @@ package vg.civcraft.mc.namelayer.listeners;
 
 import java.util.UUID;
 
+import org.bukkit.ChatColor;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
@@ -33,5 +34,6 @@ public class AssociationListener implements Listener{
 		associations.addPlayer(playername, uuid);
 		if (game != null)
 			game.setPlayerProfle(event.getPlayer());
+		event.setJoinMessage(ChatColor.YELLOW + NameAPI.getCurrentName(uuid) + " joined the game");
 	}
 }


### PR DESCRIPTION
This is a bit of a hack to be honest. I think it will work but only under a couple of circumstances. First it should only be run with the op online or preferably from the console. There is a very real possibility of a race condition possibly not with the current state of NameLayer as I believe it functions mostly in a single thread but quite possibly in newer versions.

I also encountered a bug when working on this. Because Bukkit allows listeners to PlayerJoinEvent to change the join message the join message is set before the player joins. This shouldn't be a problem for Civcraft but may well be a problem for other servers and it cost basically nothing to fix.