### PR TITLE
Allow player to set default group

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -1,6 +1,6 @@
 name: NameLayer
 main: vg.civcraft.mc.namelayer.NameLayerPlugin
-version: 2.2.100
+version: 2.2.101
 load: startup
 author: Rourke750
 commands:
@@ -29,6 +29,8 @@ commands:
    nllpt:
    nllci:
    nltaai:
+   nlsdg:
+   nlgdg:
 permissions:
    namelayer.admin:
       default: op

--- a/src/vg/civcraft/mc/namelayer/GroupManager.java
+++ b/src/vg/civcraft/mc/namelayer/GroupManager.java
@@ -200,4 +200,8 @@ public class GroupManager{
 			return x;
 		}
 	}
+	
+	public String getDefaultGroup(UUID uuid){
+		return groupManagerDao.getDefaultGroup(uuid);
+	}
 }

--- a/src/vg/civcraft/mc/namelayer/command/CommandHandler.java
+++ b/src/vg/civcraft/mc/namelayer/command/CommandHandler.java
@@ -31,6 +31,8 @@ import vg.civcraft.mc.namelayer.command.commands.ToggleAutoAcceptInvites;
 import vg.civcraft.mc.namelayer.command.commands.TransferGroup;
 import vg.civcraft.mc.namelayer.command.commands.PromotePlayer;
 import vg.civcraft.mc.namelayer.command.commands.RevokeInvite;
+import vg.civcraft.mc.namelayer.command.commands.SetDefaultGroup;
+import vg.civcraft.mc.namelayer.command.commands.GetDefaultGroup;
 
 public class CommandHandler {
 	public Map<String, Command> commands = new HashMap<String, Command>();
@@ -62,6 +64,8 @@ public class CommandHandler {
 		addCommands(new ToggleAutoAcceptInvites("AutoAcceptInvites"));
 		addCommands(new PromotePlayer("PromotePlayer"));
 		addCommands(new RevokeInvite("RevokeInvite"));
+		addCommands(new SetDefaultGroup("SetDefaultGroup"));
+		addCommands(new GetDefaultGroup("GetDefaultGroup"));
 	}
 	
 	public void addCommands(Command command){

--- a/src/vg/civcraft/mc/namelayer/command/commands/GetDefaultGroup.java
+++ b/src/vg/civcraft/mc/namelayer/command/commands/GetDefaultGroup.java
@@ -1,0 +1,59 @@
+package vg.civcraft.mc.namelayer.command.commands;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.bukkit.ChatColor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+import vg.civcraft.mc.namelayer.GroupManager.PlayerType;
+import vg.civcraft.mc.namelayer.NameAPI;
+import vg.civcraft.mc.namelayer.command.PlayerCommand;
+import vg.civcraft.mc.namelayer.command.TabCompleters.GroupTabCompleter;
+import vg.civcraft.mc.namelayer.group.Group;
+import vg.civcraft.mc.namelayer.permission.GroupPermission;
+import vg.civcraft.mc.namelayer.permission.PermissionType;
+
+public class GetDefaultGroup extends PlayerCommand{
+
+	public GetDefaultGroup(String name) {
+		super(name);
+		setIdentifier("nlgdg");
+		setDescription("This command is used to get players default group");
+		setUsage("/nlgdg");
+		setArguments(0,0);
+	}
+
+	@Override
+	public boolean execute(CommandSender sender, String[] args) {
+		if (!(sender instanceof Player)){
+			sender.sendMessage("I don't think you need to do that.");
+			return true;
+		}
+		Player p = (Player) sender;
+		UUID uuid = NameAPI.getUUID(p.getName());
+
+		String x = gm.getDefaultGroup(uuid);
+		if(x == null){
+			p.sendMessage(ChatColor.RED + "You do not currently have a default group use /nlsdg to set it");
+		}
+		else{
+			p.sendMessage(ChatColor.GREEN + "Your current default group is " + x);
+		}
+		
+		return true;
+	}
+
+	@Override
+	public List<String> tabComplete(CommandSender sender, String[] args) {
+		if (!(sender instanceof Player))
+			return null;
+
+		if (args.length == 1)
+			return GroupTabCompleter.complete(args[0], PermissionType.BLOCKS, (Player) sender);
+		else{
+			return GroupTabCompleter.complete(null, PermissionType.BLOCKS, (Player)sender);
+		}
+	}
+}

--- a/src/vg/civcraft/mc/namelayer/command/commands/SetDefaultGroup.java
+++ b/src/vg/civcraft/mc/namelayer/command/commands/SetDefaultGroup.java
@@ -1,0 +1,76 @@
+package vg.civcraft.mc.namelayer.command.commands;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.bukkit.ChatColor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+import vg.civcraft.mc.namelayer.GroupManager.PlayerType;
+import vg.civcraft.mc.namelayer.NameAPI;
+import vg.civcraft.mc.namelayer.command.PlayerCommand;
+import vg.civcraft.mc.namelayer.command.TabCompleters.GroupTabCompleter;
+import vg.civcraft.mc.namelayer.group.Group;
+import vg.civcraft.mc.namelayer.permission.GroupPermission;
+import vg.civcraft.mc.namelayer.permission.PermissionType;
+
+public class SetDefaultGroup extends PlayerCommand{
+
+	public SetDefaultGroup(String name) {
+		super(name);
+		setIdentifier("nlsdg");
+		setDescription("This command is used to set or change a default group");
+		setUsage("/nlsdg <group>");
+		setArguments(1,1);
+	}
+
+	@Override
+	public boolean execute(CommandSender sender, String[] args) {
+		if (!(sender instanceof Player)){
+			sender.sendMessage("I don't think you need to do that.");
+			return true;
+		}
+		Player p = (Player) sender;
+		UUID uuid = NameAPI.getUUID(p.getName());
+		Group g = gm.getGroup(args[0]);
+		if (g == null){
+			p.sendMessage(ChatColor.RED + "That group does not exist.");
+		}
+		
+		PlayerType pType = g.getPlayerType(uuid);
+		if (pType == null){
+			p.sendMessage(ChatColor.RED + "You do not have access to that group.");
+			return true;
+		}
+		
+		GroupPermission gPerm = gm.getPermissionforGroup(g);
+		if (!gPerm.isAccessible(pType, PermissionType.BLOCKS)){
+			p.sendMessage(ChatColor.RED + "You do not have permission to default that group.");
+			return true;
+		}
+
+		String x = gm.getDefaultGroup(uuid);
+		if(x == null){
+			g.setDefaultGroup(uuid);
+			p.sendMessage(ChatColor.GREEN + "You have set your default group to " + x);
+		}
+		else{
+			g.changeDefaultGroup(uuid);
+			p.sendMessage(ChatColor.GREEN + "You changed your default group from " + x + " to " + gm.getDefaultGroup(uuid));
+		}
+		return true;
+	}
+
+	@Override
+	public List<String> tabComplete(CommandSender sender, String[] args) {
+		if (!(sender instanceof Player))
+			return null;
+
+		if (args.length == 1)
+			return GroupTabCompleter.complete(args[0], PermissionType.BLOCKS, (Player) sender);
+		else{
+			return GroupTabCompleter.complete(null, PermissionType.BLOCKS, (Player)sender);
+		}
+	}
+}

--- a/src/vg/civcraft/mc/namelayer/group/Group.java
+++ b/src/vg/civcraft/mc/namelayer/group/Group.java
@@ -204,4 +204,18 @@ public class Group {
 	public PlayerType getPlayerType(UUID uuid){
 		return players.get(uuid);
 	}
+	
+	/**
+	 * Sets the default group for a player
+	 * @param uuid- The UUID of the player.
+	 */
+	public String setDefaultGroup(UUID uuid){
+		db.setDefaultGroup(uuid,  groupName);
+		return groupName;
+	}
+	
+	public String changeDefaultGroup(UUID uuid){
+		db.changeDefaultGroup(uuid, groupName);
+		return groupName;
+	}
 }


### PR DESCRIPTION
Creates new table in Sql which is UUID and default group

Checks if user is allowed permission to BLOCKS before allowing default
group to be set

Added 2 commands /nlsdg (set Default Group or change it)
/nlgdg gets the default group and displays it