### PR TITLE
FIx nlgs bug #71 and add in OP bypass for nllg #70

### DIFF
--- a/src/vg/civcraft/mc/namelayer/GroupManager.java
+++ b/src/vg/civcraft/mc/namelayer/GroupManager.java
@@ -150,8 +150,8 @@ public class GroupManager{
 	
 	private void initiateDefaultPerms(String group){
 		// for perms follow the order that they are in the enum PlayerType
-		String[] perms = {"DOORS CHESTS", "DOORS CHESTS BLOCKS MEMBERS CROPS", "DOORS CHESTS BLOCKS MODS MEMBERS PASSWORD LIST_PERMS CROPS",
-				"DOORS CHESTS BLOCKS ADMINS OWNER MODS MEMBERS PASSWORD SUBGROUP PERMS DELETE MERGE LIST_PERMS TRANSFER CROPS", ""};
+		String[] perms = {"DOORS CHESTS", "DOORS CHESTS BLOCKS MEMBERS CROPS", "DOORS CHESTS BLOCKS MODS MEMBERS PASSWORD LIST_PERMS CROPS GROUPSTATS",
+				"DOORS CHESTS BLOCKS ADMINS OWNER MODS MEMBERS PASSWORD SUBGROUP PERMS DELETE MERGE LIST_PERMS TRANSFER CROPS GROUPSTATS", ""};
 		int x = 0;
 		for (PlayerType role: PlayerType.values()){
 			groupManagerDao.addPermission(group, role.name(), perms[x]);

--- a/src/vg/civcraft/mc/namelayer/command/commands/GroupStats.java
+++ b/src/vg/civcraft/mc/namelayer/command/commands/GroupStats.java
@@ -14,6 +14,7 @@ import vg.civcraft.mc.namelayer.NameLayerPlugin;
 import vg.civcraft.mc.namelayer.command.PlayerCommand;
 import vg.civcraft.mc.namelayer.command.TabCompleters.GroupTabCompleter;
 import vg.civcraft.mc.namelayer.group.Group;
+import vg.civcraft.mc.namelayer.permission.GroupPermission;
 import vg.civcraft.mc.namelayer.permission.PermissionType;
 
 public class GroupStats extends PlayerCommand {
@@ -34,14 +35,20 @@ public class GroupStats extends PlayerCommand {
 		}
 		Player p = (Player) sender;
 		Group g = gm.getGroup(args[0]);
-		UUID uuid = NameAPI.getUUID(p.getName());
+		UUID uuid = NameAPI.getUUID(p.getName());	
 		
 		if (g == null){
 			p.sendMessage(ChatColor.RED + "That group does not exist.");
 			return true;
 		}
+		PlayerType pType = g.getPlayerType(uuid);
 		if (!g.isMember(uuid) && !(p.isOp() || p.hasPermission("namelayer.admin"))){
 			p.sendMessage(ChatColor.RED + "You are not on this group.");
+			return true;
+		}
+		GroupPermission gPerm = gm.getPermissionforGroup(g);
+		if (!gPerm.isAccessible(pType, PermissionType.GROUPSTATS) && !(p.isOp() || p.hasPermission("namelayer.admin"))){
+			p.sendMessage(ChatColor.RED + "You do not have permission to run that command.");
 			return true;
 		}
 		

--- a/src/vg/civcraft/mc/namelayer/command/commands/InvitePlayer.java
+++ b/src/vg/civcraft/mc/namelayer/command/commands/InvitePlayer.java
@@ -93,7 +93,7 @@ public class InvitePlayer extends PlayerCommand{
 		}
 		
 		if (group.isMember(uuid)){ // So a player can't demote someone who is above them.
-			p.sendMessage(ChatColor.RED + "Player is already a member. They "
+			p.sendMessage(ChatColor.RED + "Player is already a member."
 					+ "Use /nlpp to change their PlayerType.");
 			return true;
 		}

--- a/src/vg/civcraft/mc/namelayer/command/commands/ListGroups.java
+++ b/src/vg/civcraft/mc/namelayer/command/commands/ListGroups.java
@@ -23,12 +23,22 @@ public class ListGroups extends PlayerCommand {
 
 	@Override
 	public boolean execute(CommandSender sender, String[] args) {
-		if (!(sender instanceof Player)){
-			sender.sendMessage("Nope.");
-			return true;
+		Player p = null;
+		UUID uuid = null;
+		Boolean autopages = false;
+		if ((sender.isOp() && sender.hasPermission("namelayer.admin"))) {
+            uuid = NameAPI.getUUID(args[0]);
+            if(uuid == null){
+            	sender.sendMessage(ChatColor.RED + "UUID is NULL,  OP Usage is /nllg <playername>");
+            	return true;
+            }
+            autopages = true;
+        }
+		else{
+			p = (Player) sender;
+			uuid = NameAPI.getUUID(p.getName());
 		}
-		Player p = (Player) sender;
-		UUID uuid = NameAPI.getUUID(p.getName());
+		
 		List<String> groups = gm.getAllGroupNames(uuid);
 		
 		int pages = (groups.size() / 10) + 1;
@@ -43,13 +53,29 @@ public class ListGroups extends PlayerCommand {
 			}
 		}
 		
-		names += "Page " + start + " of " + pages + ".\n"
-				+ "Groups are as follows: \n";
-		for (int x = (start-1) * 10, z = 1; x < groups.size() && z <= 10; x++, z++){
-			Group g = gm.getGroup(groups.get(x));
-			names += g.getName() + ": (PlayerType) " + g.getPlayerType(uuid).toString() + "\n";
+		
+		if(autopages){
+			for(int curPage = 1; curPage <= pages; curPage++)
+				{
+					start = curPage;
+					names += "Page " + start + " of " + pages + ".\n"
+							+ "Groups are as follows: \n";
+					for (int x = (start-1) * 10, z = 1; x < groups.size() && z <= 10; x++, z++){
+						Group g = gm.getGroup(groups.get(x));
+						names += g.getName() + ": (PlayerType) " + g.getPlayerType(uuid).toString() + "\n";
+					}
+				}
+			sender.sendMessage(names);
 		}
-		p.sendMessage(names);
+		else{
+			names += "Page " + start + " of " + pages + ".\n"
+					+ "Groups are as follows: \n";
+			for (int x = (start-1) * 10, z = 1; x < groups.size() && z <= 10; x++, z++){
+				Group g = gm.getGroup(groups.get(x));
+				names += g.getName() + ": (PlayerType) " + g.getPlayerType(uuid).toString() + "\n";
+			}
+			p.sendMessage(names);
+		}
 		return true;
 	}
 	public List<String> tabComplete(CommandSender sender, String[] args) {

--- a/src/vg/civcraft/mc/namelayer/permission/PermissionType.java
+++ b/src/vg/civcraft/mc/namelayer/permission/PermissionType.java
@@ -29,7 +29,8 @@ public enum PermissionType {
 	MERGE, // Gives the player permission to merge the group.
 	LIST_PERMS, // Allows the player to use the command to list the perms of a PlayerType
 	TRANSFER, // Allows the player to transfer the group
-	CROPS; // Allows access to crops, mainly used for citadel.
+	CROPS, // Allows access to crops, mainly used for citadel.
+	GROUPSTATS; //Allows access to nlgs command for group
 	
 	public static PermissionType getPermissionType(String type){
 		PermissionType pType = null;


### PR DESCRIPTION
Update permissions to include permission GROUPSTATS for nlgs command

Update nllg to have admin bypass

Update PermissionType to have GROUPSTATS

update GroupManager to have default permissions for GROUPSTATS to owners
and admins

update InvitePlayer to give sender the right message

Someone will still have to modify the database 'permissions' for existings
groups and insert GROUPSTATS into tier where role= ADMINS or OWNER