### PR TITLE
Added info about accepting Namelayer invites to the notification sent on...

### DIFF
--- a/src/vg/civcraft/mc/namelayer/listeners/PlayerListener.java
+++ b/src/vg/civcraft/mc/namelayer/listeners/PlayerListener.java
@@ -37,7 +37,7 @@ public class PlayerListener implements Listener{
 			x = "You have auto-accepted invitation from the following groups while you were away: ";
 		}
 		else{
-			x = "You have been invited to the following groups while you were away: ";
+			x = "You have been invited to the following groups while you were away. You can accept each invitaion by using the command: /nlag [groupname].  ";
 		}			
 		
 		for (Group g:notifications .get(uuid)){


### PR DESCRIPTION
... login to players with pending invites

This change makes it easier for people unfamiliar with Namelayer to easily accept invitations sent to them while they were offline.