### PR TITLE
Possible fix for Civcraft/CivChat2/issues/5

### DIFF
--- a/src/vg/civcraft/mc/namelayer/database/AssociationList.java
+++ b/src/vg/civcraft/mc/namelayer/database/AssociationList.java
@@ -101,7 +101,7 @@ public class AssociationList {
 		try {
 			getUUIDfromPlayer.setString(1, playername);
 			ResultSet set = getUUIDfromPlayer.executeQuery();
-			if (!set.next()) return null;
+			if (!set.next() || set.wasNull()) return null;
 			String uuid = set.getString("uuid");
 			return UUID.fromString(uuid);
 		} catch (SQLException e) {


### PR DESCRIPTION
I believe this pull should patch the problem listed in Civcraft/CivChat2/issues/5 and below stack trace:
```
2015-05-16 18:39:27 [ERROR] Could not pass event AsyncPlayerChatEvent to CivChat2 v1.0.1
org.bukkit.event.EventException
at org.bukkit.plugin.java.JavaPluginLoader$1.execute(JavaPluginLoader.java:305) ~[spigot.jar:git-Spigot-1d14d5f-7722428]
at org.bukkit.plugin.RegisteredListener.callEvent(RegisteredListener.java:62) ~[spigot.jar:git-Spigot-1d14d5f-7722428]
at org.bukkit.plugin.SimplePluginManager.fireEvent(SimplePluginManager.java:502) [spigot.jar:git-Spigot-1d14d5f-7722428]
at org.bukkit.plugin.SimplePluginManager.callEvent(SimplePluginManager.java:484) [spigot.jar:git-Spigot-1d14d5f-7722428]
at net.minecraft.server.v1_8_R2.PlayerConnection.chat(PlayerConnection.java:1061) [spigot.jar:git-Spigot-1d14d5f-7722428]
at net.minecraft.server.v1_8_R2.PlayerConnection.a(PlayerConnection.java:999) [spigot.jar:git-Spigot-1d14d5f-7722428]
at net.minecraft.server.v1_8_R2.PacketPlayInChat$1.run(PacketPlayInChat.java:39) [spigot.jar:git-Spigot-1d14d5f-7722428]
at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511) [?:1.8.0_45-internal]
at java.util.concurrent.FutureTask.run(FutureTask.java:266) [?:1.8.0_45-internal]
at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142) [?:1.8.0_45-internal]
at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617) [?:1.8.0_45-internal]
at java.lang.Thread.run(Thread.java:745) [?:1.8.0_45-internal]
Caused by: java.lang.NullPointerException
at com.mysql.jdbc.ResultSetImpl.buildIndexMapping(ResultSetImpl.java:754) ~[spigot.jar:git-Spigot-1d14d5f-7722428]
at com.mysql.jdbc.ResultSetImpl.findColumn(ResultSetImpl.java:1108) ~[spigot.jar:git-Spigot-1d14d5f-7722428]
at com.mysql.jdbc.ResultSetImpl.getString(ResultSetImpl.java:5616) ~[spigot.jar:git-Spigot-1d14d5f-7722428]
at vg.civcraft.mc.namelayer.database.AssociationList.getUUID(AssociationList.java:105) ~[?:?]
at vg.civcraft.mc.namelayer.NameAPI.getUUID(NameAPI.java:24) ~[?:?]
at vg.civcraft.mc.civchat2.CivChat2Manager.broadcastMessage(CivChat2Manager.java:222) ~[?:?]
at vg.civcraft.mc.civchat2.listeners.CivChat2Listener.PlayerChatEvent(CivChat2Listener.java:102) ~[?:?]
at sun.reflect.GeneratedMethodAccessor153.invoke(Unknown Source) ~[?:?]
at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:1.8.0_45-internal]
at java.lang.reflect.Method.invoke(Method.java:497) ~[?:1.8.0_45-internal]
at org.bukkit.plugin.java.JavaPluginLoader$1.execute(JavaPluginLoader.java:301) ~[spigot.jar:git-Spigot-1d14d5f-7722428]
... 11 more
```