### PR TITLE
Changing /nllm to allow searching for namerange

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<groupId>vg.civcraft.mc.namelayer</groupId>
 	<artifactId>NameLayer</artifactId>
 	<packaging>jar</packaging>
-	<version>2.4.9</version>
+	<version>2.5.0</version>
 	<name>NameLayer</name>
 	<url>https://github.com/Civcraft/NameLayer/</url>
 

--- a/src/vg/civcraft/mc/namelayer/command/commands/ListMembers.java
+++ b/src/vg/civcraft/mc/namelayer/command/commands/ListMembers.java
@@ -22,7 +22,7 @@ public class ListMembers extends PlayerCommandMiddle{
 		setIdentifier("nllm");
 		setDescription("List the members in a group");
 		setUsage("/nllm <group> (PlayerType)");
-		setArguments(1,2);
+		setArguments(1,3);
 	}
 
 	@Override
@@ -50,12 +50,17 @@ public class ListMembers extends PlayerCommandMiddle{
 		
 		List<UUID> uuids = null;
 		if (args.length > 1){
-			PlayerType type = PlayerType.getPlayerType(args[1]);
-			if (type == null){
-				PlayerType.displayPlayerTypes(p);
-				return true;
+			if (args.length == 3) {
+				uuids = g.getMembersInNameRange(args[1], args[2]);
 			}
-			uuids = g.getAllMembers(type);
+			else {
+				PlayerType type = PlayerType.getPlayerType(args[1]);
+				if (type == null){
+					PlayerType.displayPlayerTypes(p);
+					return true;
+				}
+				uuids = g.getAllMembers(type);
+			}
 		}
 		else
 			uuids = g.getAllMembers();

--- a/src/vg/civcraft/mc/namelayer/group/Group.java
+++ b/src/vg/civcraft/mc/namelayer/group/Group.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import java.util.UUID;
 
 import vg.civcraft.mc.namelayer.GroupManager.PlayerType;
+import vg.civcraft.mc.namelayer.NameAPI;
 import vg.civcraft.mc.namelayer.NameLayerPlugin;
 import vg.civcraft.mc.namelayer.database.GroupManagerDao;
 
@@ -61,6 +62,25 @@ public class Group {
 				uuids.add(uu);
 		return uuids;
 	}
+	
+	/**
+	 * Gives the uuids of players who are in this group and whos name is
+	 * within the given range. 
+	 * @param lowerLimit lexicographically lowest acceptable name
+	 * @param upperLimit lexicographically highest acceptable name
+	 * @return list of uuids of all players in the group whose name is within the given range
+	 */
+	public List<UUID> getMembersInNameRange(String lowerLimit, String upperLimit) {
+		List<UUID> uuids = new ArrayList<UUID>();
+		for (UUID uu: players.keySet()) {
+			String name = NameAPI.getCurrentName(uu);
+			if (name.compareToIgnoreCase(lowerLimit) >= 0 && name.compareToIgnoreCase(upperLimit) <= 0) {
+				uuids.add(uu);
+			}
+		}
+		return uuids;
+	}
+	
 	/**
 	 * Adds the player to be allowed to join a group into a specific PlayerType.
 	 * @param uuid- The UUID of the player.


### PR DESCRIPTION
Sometimes there is a situation where you want to check whether someone is in a group, currently there are 3 solutions for this: Trying to remove the person from the group, trying to invite the person to the group and listing all members and try to find the name in the list.

All of those solutions are suboptimal in certain situations and there is also https://github.com/Civcraft/NameLayer/issues/135 , so I changed /nllm here to allow players to search for members within a given namerange. Doing stuff like "/nllm mods" still works, but with this someone could also do "/nllm a f" to list all player whose names start with a letter inbetween a and f or "/nllm ttk1 ttk3" to see whether ttk2 is on a group.

@rourke750  thoughts?