### PR TITLE
Name length and overlap fix

### DIFF
--- a/NameLayer/pom.xml
+++ b/NameLayer/pom.xml
@@ -6,7 +6,7 @@
 	<groupId>vg.civcraft.mc.namelayer</groupId>
 	<artifactId>NameLayer</artifactId>
 	<packaging>jar</packaging>
-	<version>2.6.2</version>
+	<version>2.6.3</version>
 	<name>NameLayer</name>
 	<url>https://github.com/Civcraft/NameLayer/</url>			  
 	


### PR DESCRIPTION
Building on collaborative effort from @Maxopoly and @Erocs, pull to address #67

Removes need for "name count" table and ensures renames are still at or under 16 characters.