### PR TITLE
Add caching for default groups to prevent constant querying of db

### DIFF
--- a/NameLayer/pom.xml
+++ b/NameLayer/pom.xml
@@ -6,7 +6,7 @@
 	<groupId>vg.civcraft.mc.namelayer</groupId>
 	<artifactId>NameLayer</artifactId>
 	<packaging>jar</packaging>
-	<version>2.7.02</version>
+	<version>2.7.10</version>
 	<name>NameLayer</name>
 	<url>https://github.com/Civcraft/NameLayer/</url>			  
 	

--- a/NameLayerMain/src/vg/civcraft/mc/namelayer/GroupManager.java
+++ b/NameLayerMain/src/vg/civcraft/mc/namelayer/GroupManager.java
@@ -395,7 +395,7 @@ public class GroupManager{
 			NameLayerPlugin.getInstance().getLogger().log(Level.INFO, "getDefaultGroup was cancelled, caller passed in null", new Exception());
 			return null;
 		}
-		return groupManagerDao.getDefaultGroup(uuid);
+		return NameLayerPlugin.getDefaultGroupHandler().getDefaultGroup(uuid);
 	}
 
 	/**

--- a/NameLayerMain/src/vg/civcraft/mc/namelayer/NameLayerPlugin.java
+++ b/NameLayerMain/src/vg/civcraft/mc/namelayer/NameLayerPlugin.java
@@ -17,6 +17,7 @@ import vg.civcraft.mc.namelayer.database.AssociationList;
 import vg.civcraft.mc.namelayer.database.Database;
 import vg.civcraft.mc.namelayer.database.GroupManagerDao;
 import vg.civcraft.mc.namelayer.group.BlackList;
+import vg.civcraft.mc.namelayer.group.DefaultGroupHandler;
 import vg.civcraft.mc.namelayer.listeners.AssociationListener;
 import vg.civcraft.mc.namelayer.listeners.MercuryMessageListener;
 import vg.civcraft.mc.namelayer.listeners.PlayerListener;
@@ -28,6 +29,7 @@ public class NameLayerPlugin extends ACivMod{
 	private static AssociationList associations;
 	private static BlackList blackList;
 	private static GroupManagerDao groupManagerDao;
+	private static DefaultGroupHandler defaultGroupHandler;
 	private static NameLayerPlugin instance;
 	private CommandHandler handle;
 	private static Database db;
@@ -55,6 +57,7 @@ public class NameLayerPlugin extends ACivMod{
 		PermissionType.initialize();
 		blackList = new BlackList();
 		groupManagerDao.loadGroupsInvitations();
+		defaultGroupHandler = new DefaultGroupHandler();
 		registerListeners();
 		if (loadGroups){
 			handle = new CommandHandler();
@@ -197,5 +200,9 @@ public class NameLayerPlugin extends ACivMod{
 	
 	public static BlackList getBlackList() {
 		return blackList;
+	}
+	
+	public static DefaultGroupHandler getDefaultGroupHandler() {
+		return defaultGroupHandler;
 	}
 }

--- a/NameLayerMain/src/vg/civcraft/mc/namelayer/database/GroupManagerDao.java
+++ b/NameLayerMain/src/vg/civcraft/mc/namelayer/database/GroupManagerDao.java
@@ -383,7 +383,7 @@ public class GroupManagerDao {
 	
 	private PreparedStatement addAutoAcceptGroup, getAutoAcceptGroup, removeAutoAcceptGroup;
 	
-	private PreparedStatement setDefaultGroup, changeDefaultGroup, getDefaultGroup;
+	private PreparedStatement setDefaultGroup, changeDefaultGroup, getDefaultGroup, getAllDefaultGroups;
 	
 	private PreparedStatement loadGroupsInvitations, addGroupInvitation, removeGroupInvitation, loadGroupInvitation;
 	
@@ -486,6 +486,7 @@ public class GroupManagerDao {
 		
 		getDefaultGroup = db.prepareStatement("select defaultgroup from default_group "
 				+ "where uuid = ?");
+		getAllDefaultGroups = db.prepareStatement("select uuid,defaultgroup from defaultgroup");
 		
 		loadGroupsInvitations = db.prepareStatement("select uuid, groupName, role from group_invitation");
 		
@@ -1066,6 +1067,22 @@ public class GroupManagerDao {
 			plugin.getLogger().log(Level.WARNING, "Problem getting default group for " + uuid, e);
 		}
 		return null;
+	}
+	
+	public synchronized Map <UUID, String> getAllDefaultGroups() {
+		Map <UUID, String> groups = null;
+		try {
+			ResultSet set = getAllDefaultGroups.executeQuery();
+			groups = new TreeMap<UUID, String>();
+			while(set.next()) {
+				UUID uuid = UUID.fromString(set.getString(1));
+				String group = set.getString(2);
+				groups.put(uuid, group);
+			}
+		} catch (SQLException e) {
+			plugin.getLogger().log(Level.WARNING, "Problem getting all default groups " , e);
+		}
+		return groups;
 	}
 	
 	/**

--- a/NameLayerMain/src/vg/civcraft/mc/namelayer/database/GroupManagerDao.java
+++ b/NameLayerMain/src/vg/civcraft/mc/namelayer/database/GroupManagerDao.java
@@ -486,7 +486,7 @@ public class GroupManagerDao {
 		
 		getDefaultGroup = db.prepareStatement("select defaultgroup from default_group "
 				+ "where uuid = ?");
-		getAllDefaultGroups = db.prepareStatement("select uuid,defaultgroup from defaultgroup");
+		getAllDefaultGroups = db.prepareStatement("select uuid,defaultgroup from default_group");
 		
 		loadGroupsInvitations = db.prepareStatement("select uuid, groupName, role from group_invitation");
 		

--- a/NameLayerMain/src/vg/civcraft/mc/namelayer/group/DefaultGroupHandler.java
+++ b/NameLayerMain/src/vg/civcraft/mc/namelayer/group/DefaultGroupHandler.java
@@ -1,0 +1,54 @@
+package vg.civcraft.mc.namelayer.group;
+
+import java.util.Map;
+import java.util.UUID;
+
+import org.bukkit.entity.Player;
+
+import vg.civcraft.mc.mercury.MercuryAPI;
+import vg.civcraft.mc.namelayer.NameLayerPlugin;
+import vg.civcraft.mc.namelayer.database.GroupManagerDao;
+
+public class DefaultGroupHandler {
+	
+	private GroupManagerDao dao;
+	
+	private Map <UUID, String> defaultGroups;
+	
+	public DefaultGroupHandler() {
+		dao = NameLayerPlugin.getGroupManagerDao();
+		defaultGroups = dao.getAllDefaultGroups();
+	}
+	
+	public String getDefaultGroup(Player p) {
+		return getDefaultGroup(p.getUniqueId());
+	}
+	
+	public String getDefaultGroup(UUID uuid) {
+		return defaultGroups.get(uuid);
+	}
+	
+	public void setDefaultGroup(Player p, Group g) {
+		setDefaultGroup(p.getUniqueId(), g);
+	}
+	
+	public void setDefaultGroup(UUID uuid, Group g) {
+		String previous = defaultGroups.get(uuid);
+		if (previous == null) {
+			dao.setDefaultGroup(uuid, g.getName());
+		}
+		else {
+			dao.changeDefaultGroup(uuid, g.getName());
+		}
+		defaultGroups.put(uuid, g.getName());
+		if (NameLayerPlugin.isMercuryEnabled()) {
+			MercuryAPI.sendGlobalMessage("defaultGroup " + uuid.toString(), "namelayer");
+		}
+	}
+	
+	public String recacheDefaultGroup(UUID uuid) {
+		String gName = dao.getDefaultGroup(uuid);
+		defaultGroups.put(uuid, gName);
+		return gName;
+	}
+}

--- a/NameLayerMain/src/vg/civcraft/mc/namelayer/group/Group.java
+++ b/NameLayerMain/src/vg/civcraft/mc/namelayer/group/Group.java
@@ -404,14 +404,14 @@ public class Group {
 	/**
 	 * Sets the default group for a player
 	 * @param uuid- The UUID of the player.
+	 * 
 	 */
-	public String setDefaultGroup(UUID uuid) {
-		db.setDefaultGroup(uuid,  name);
-		return name;
+	public void setDefaultGroup(UUID uuid) {
+		NameLayerPlugin.getDefaultGroupHandler().setDefaultGroup(uuid, this);
 	}
 
 	public void changeDefaultGroup(UUID uuid) {
-		db.changeDefaultGroup(uuid, name);
+		NameLayerPlugin.getDefaultGroupHandler().setDefaultGroup(uuid, this);
 	}
 	
 	// == GETTERS ========================================================================= //

--- a/NameLayerMain/src/vg/civcraft/mc/namelayer/listeners/MercuryMessageListener.java
+++ b/NameLayerMain/src/vg/civcraft/mc/namelayer/listeners/MercuryMessageListener.java
@@ -11,6 +11,7 @@ import vg.civcraft.mc.mercury.MercuryAPI;
 import vg.civcraft.mc.mercury.events.AsyncPluginBroadcastMessageEvent;
 import vg.civcraft.mc.namelayer.GroupManager;
 import vg.civcraft.mc.namelayer.GroupManager.PlayerType;
+import vg.civcraft.mc.namelayer.NameLayerPlugin;
 import vg.civcraft.mc.namelayer.command.commands.InvitePlayer;
 import vg.civcraft.mc.namelayer.NameAPI;
 import vg.civcraft.mc.namelayer.events.GroupAddInvitation;
@@ -87,6 +88,10 @@ public class MercuryMessageListener implements Listener{
 				playerGroup.removeInvite(invitedPlayerUUID, false);
 				PlayerListener.removeNotification(invitedPlayerUUID, playerGroup);
 			}
+		}
+		else if (reason.equals("defaultGroup")) {
+			UUID playerUUID = UUID.fromString(message [1]);
+			NameLayerPlugin.getDefaultGroupHandler().recacheDefaultGroup(playerUUID);			
 		}
 	}
 }


### PR DESCRIPTION
I kept the old API layer for default groups, but made it use the caching. Would be nice if someone could take a look over this to ensure I didnt miss something

@rourke750 @ProgrammerDan 